### PR TITLE
Tiers proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,117 +4,117 @@ Version 4.0
 
 ## Schema
 
-| Field | Type | Examples | Description |
-| ----- | ---- | -------- | ----------- |
-| `ogc_fid` | `serial primary key` |  | object ID |
-| `geoid` | `text` |  | FIPS code |
-| `sourceagent` | `text` |  | Source Agent |
-| `parcelnumb` | `text` | 02004940, 001-020-4624-001 | Parcel ID |
-| `usecode` | `text` |  | Parcel Use Code |
-| `usedesc` | `text` |  | Parcel Use Description |
-| `zoning` | `text` |  | Zoning Code |
-| `zoning_description` | `text` |  | Zoning Description |
-| `struct` | `boolean` |  | Structure On Parcel |
-| `multistruct` | `boolean` |  | Multiple Structures on Parcel |
-| `structno` | `integer` |  | Number of Structures on Parcel |
-| `yearbuilt` | `integer` |  | Structure Year Built |
-| `numstories` | `double precision` |  | Number of Stories |
-| `numunits` | `integer` |  | Number of Units |
-| `structstyle` | `text` |  | Structure Style |
-| `parvaltype` | `text` | Appraised, Assessed, Taxable, Market, Market Value | Parcel Value Type |
-| `improvval` | `double precision` |  | Improvement Value |
-| `landval` | `double precision` |  | Land Value |
-| `parval` | `double precision` |  | Total Parcel Value |
-| `agval` | `double precision` |  | Agricultural Value |
-| `saleprice` | `double precision` |  | Last Sale Price |
-| `saledate` | `date` |  | Last Sale Date |
-| `taxamt` | `double precision` |  | Annual Tax Bill |
-| `owntype` | `text` |  | Owner Type |
-| `owner` | `text` |  | Owner Name |
-| `ownfrst` | `text` |  | Owner First Name |
-| `ownlast` | `text` |  | Owner Last Name |
-| `owner2` | `text` |  | Second Owner Name |
-| `owner3` | `text` |  | Third Owner Name |
-| `owner4` | `text` |  | Fourth Owner Name |
-| `subsurfown` | `text` |  | Subsurface Owner |
-| `subowntype` | `text` |  | Subsurface Owner Type |
-| `mailadd` | `text` |  | Owner Mailing Address |
-| `mail_address2` | `text` |  | Owner Mailing Address Second Line |
-| `careof` | `text` |  | Owner Mailing Address Care Of |
-| `mail_addno` | `text` |  | Owner Mailing Address Street Number |
-| `mail_addpref` | `text` |  | Owner Mailing Address Street Prefix |
-| `mail_addstr` | `text` |  | Owner Mailing Address Street Name |
-| `mail_addsttyp` | `text` |  | Owner Mailing Address Street Type |
-| `mail_addstsuf` | `text` |  | Owner Mailing Address Street Suffix |
-| `mail_unit` | `text` |  | Owner Mailing Address Unit Number |
-| `mail_city` | `text` |  | Owner Mailing Address City |
-| `mail_state2` | `text` |  | Owner Mailing Address State |
-| `mail_zip` | `text` |  | Owner Mailing Address ZIP Code |
-| `mail_urbanization` | `text` |  | Mailing Address Urbanizacion (Puerto Rico) |
-| `address` | `text` |  | Site Address |
-| `address2` | `text` |  | Site Address Second Line |
-| `saddno` | `text` |  | Site Address Number |
-| `saddpref` | `text` |  | Site Address Prefix |
-| `saddstr` | `text` |  | Site Address Street Name |
-| `saddsttyp` | `text` |  | Site Address Street Type |
-| `saddstsuf` | `text` |  | Site Address Street Suffix |
-| `sunit` | `text` |  | Site Address Unit |
-| `scity` | `text` |  | Site Address City |
-| `original_address` | `text` |  | Original Address |
-| `city` | `text` |  | Census City |
-| `county` | `text` |  | Site Address County |
-| `state2` | `text` |  | Site Address State |
-| `szip` | `text` |  | Site Address Zip Code |
-| `urbanization` | `text` |  | Site Urbanizacion |
-| `location_name` | `text` |  | Location Name |
-| `address_source` | `text` |  | Primary Address Source |
-| `legaldesc` | `text` |  | Legal Description |
-| `plat` | `text` |  | Plat |
-| `book` | `text` |  | Book |
-| `page` | `text` |  | Page |
-| `block` | `text` |  | Block |
-| `lot` | `text` |  | Lot |
-| `neighborhood` | `text` |  | Neighborhood |
-| `subdivision` | `text` |  | Subdivision |
-| `qoz` | `text` |  | Federal Qualified Opportunity Zone |
-| `qoz_tract` | `text` |  | Qualified Opportunity Zone 2018 Census Tract Number |
-| `census_tract` | `text` |  | Census 2010 Tract |
-| `census_block` | `text` |  | Census 2010 Block |
-| `census_blockgroup` | `text` |  | Census 2010 Blockgroup |
-| `sourceref` | `text` |  | Source Document Reference |
-| `sourcedate` | `date` |  | Source Document Date |
-| `sourceurl` | `text` |  | Source URL |
-| `recrdareatx` | `text` |  | Recorded Area (text) |
-| `recrdareano` | `double precision` |  | Recorded Area (number) |
-| `gisacre` | `double precision` |  | County-Provided Acres |
-| `sqft` | `double precision` |  | County-Provided Parcel Square Feet |
-| `ll_gisacre` | `double precision` |  | Loveland Calculated Parcel Acres |
-| `ll_gissqft` | `bigint` |  | Loveland Calculated Parcel Square Feet |
-| `ll_bldg_footprint_sqft` | `integer` |  | Loveland Calculated Building Footprint Square Feet |
-| `ll_bldg_count` | `integer` |  | Loveland Calculated Building Count |
-| `reviseddate` | `date` |  | Date of Last Revision |
-| `path` | `text` |  | Parcel Path |
-| `ll_stable_id` | `text` | preserved (if unchanged) | Stable ID |
-| `ll_uuid` | `UUID` |  | Version 4 UUID |
-| `ll_updated_at` | `timestamp with time zone` |  | Updated At |
-| `dpv_status` | `text` |  | USPS Delivery Point Validation |
-| `dpv_codes` | `text` |  | Delivery Point Validation Codes |
-| `dpv_notes` | `text` |  | Delivery Point Validation Notes |
-| `dpv_type` | `text` |  | Delivery Point Match Type |
-| `cass_errorno` | `text` |  | CASS Certification Error Codes |
-| `rdi` | `text` |  | Residential Delivery Indicator |
-| `usps_vacancy` | `text` |  | USPS Vacancy Indicator |
-| `usps_vacancy_date` | `date` |  | USPS Vacancy Indicator Date |
-| `lbcs_activity` | `numeric` |  | LBCS Activity Code |
-| `lbcs_activity_desc` | `text` |  | LBCS Activity Code text description |
-| `lbcs_function` | `numeric` |  | LBCS Function Code |
-| `lbcs_function_desc` | `text` |  | LBCS Function Code text description |
-| `lbcs_structure` | `numeric` |  | LBCS Structure Code |
-| `lbcs_structure_desc` | `text` |  | LBCS Structure Code text description |
-| `lbcs_site` | `numeric` |  | LBCS Site Code |
-| `lbcs_site_desc` | `text` |  | LBCS Site Code text description |
-| `lbcs_ownership` | `numeric` |  | LBCS Ownership Code |
-| `lbcs_ownership_desc` | `text` |  | LBCS Ownership Code text description |
+| Field | Tier | Type | Examples | Description |
+| ----- | ---- | ---- | -------- | ----------- |
+| `ogc_fid` | basic | `serial primary key` |  | object ID |
+| `geoid` | basic | `text` |  | FIPS code |
+| `sourceagent` | basic | `text` |  | Source Agent |
+| `parcelnumb` | basic | `text` | 02004940, 001-020-4624-001 | Parcel ID |
+| `usecode` | standard | `text` |  | Parcel Use Code |
+| `usedesc` | standard | `text` |  | Parcel Use Description |
+| `zoning` | standard | `text` |  | Zoning Code |
+| `zoning_description` | standard | `text` |  | Zoning Description |
+| `struct` | standard | `boolean` |  | Structure On Parcel |
+| `multistruct` | standard | `boolean` |  | Multiple Structures on Parcel |
+| `structno` | standard | `integer` |  | Number of Structures on Parcel |
+| `yearbuilt` | standard | `integer` |  | Structure Year Built |
+| `numstories` | standard | `double precision` |  | Number of Stories |
+| `numunits` | standard | `integer` |  | Number of Units |
+| `structstyle` | standard | `text` |  | Structure Style |
+| `parvaltype` | standard | `text` | Appraised, Assessed, Taxable, Market, Market Value | Parcel Value Type |
+| `improvval` | standard | `double precision` |  | Improvement Value |
+| `landval` | standard | `double precision` |  | Land Value |
+| `parval` | standard | `double precision` |  | Total Parcel Value |
+| `agval` | standard | `double precision` |  | Agricultural Value |
+| `saleprice` | standard | `double precision` |  | Last Sale Price |
+| `saledate` | standard | `date` |  | Last Sale Date |
+| `taxamt` | standard | `double precision` |  | Annual Tax Bill |
+| `owntype` | standard | `text` |  | Owner Type |
+| `owner` | basic | `text` |  | Owner Name |
+| `ownfrst` | basic | `text` |  | Owner First Name |
+| `ownlast` | basic | `text` |  | Owner Last Name |
+| `owner2` | basic | `text` |  | Second Owner Name |
+| `owner3` | basic | `text` |  | Third Owner Name |
+| `owner4` | basic | `text` |  | Fourth Owner Name |
+| `subsurfown` | standard | `text` |  | Subsurface Owner |
+| `subowntype` | standard | `text` |  | Subsurface Owner Type |
+| `mailadd` | standard | `text` |  | Owner Mailing Address |
+| `mail_address2` | standard | `text` |  | Owner Mailing Address Second Line |
+| `careof` | standard | `text` |  | Owner Mailing Address Care Of |
+| `mail_addno` | standard | `text` |  | Owner Mailing Address Street Number |
+| `mail_addpref` | standard | `text` |  | Owner Mailing Address Street Prefix |
+| `mail_addstr` | standard | `text` |  | Owner Mailing Address Street Name |
+| `mail_addsttyp` | standard | `text` |  | Owner Mailing Address Street Type |
+| `mail_addstsuf` | standard | `text` |  | Owner Mailing Address Street Suffix |
+| `mail_unit` | standard | `text` |  | Owner Mailing Address Unit Number |
+| `mail_city` | standard | `text` |  | Owner Mailing Address City |
+| `mail_state2` | standard | `text` |  | Owner Mailing Address State |
+| `mail_zip` | standard | `text` |  | Owner Mailing Address ZIP Code |
+| `mail_urbanization` | standard | `text` |  | Mailing Address Urbanizacion (Puerto Rico) |
+| `address` | basic | `text` |  | Site Address |
+| `address2` | basic | `text` |  | Site Address Second Line |
+| `saddno` | basic | `text` |  | Site Address Number |
+| `saddpref` | basic | `text` |  | Site Address Prefix |
+| `saddstr` | basic | `text` |  | Site Address Street Name |
+| `saddsttyp` | basic | `text` |  | Site Address Street Type |
+| `saddstsuf` | basic | `text` |  | Site Address Street Suffix |
+| `sunit` | basic | `text` |  | Site Address Unit |
+| `scity` | basic | `text` |  | Site Address City |
+| `original_address` | basic | `text` |  | Original Address |
+| `city` | basic | `text` |  | Census City |
+| `county` | basic | `text` |  | Site Address County |
+| `state2` | basic | `text` |  | Site Address State |
+| `szip` | basic | `text` |  | Site Address Zip Code |
+| `urbanization` | basic | `text` |  | Site Urbanizacion |
+| `location_name` | basic | `text` |  | Location Name |
+| `address_source` | basic | `text` |  | Primary Address Source |
+| `legaldesc` | standard | `text` |  | Legal Description |
+| `plat` | standard | `text` |  | Plat |
+| `book` | standard | `text` |  | Book |
+| `page` | standard | `text` |  | Page |
+| `block` | standard | `text` |  | Block |
+| `lot` | standard | `text` |  | Lot |
+| `neighborhood` | standard | `text` |  | Neighborhood |
+| `subdivision` | standard | `text` |  | Subdivision |
+| `qoz` | standard | `text` |  | Federal Qualified Opportunity Zone |
+| `qoz_tract` | standard | `text` |  | Qualified Opportunity Zone 2018 Census Tract Number |
+| `census_tract` | standard | `text` |  | Census 2010 Tract |
+| `census_block` | standard | `text` |  | Census 2010 Block |
+| `census_blockgroup` | standard | `text` |  | Census 2010 Blockgroup |
+| `sourceref` | basic | `text` |  | Source Document Reference |
+| `sourcedate` | basic | `date` |  | Source Document Date |
+| `sourceurl` | basic | `text` |  | Source URL |
+| `recrdareatx` | standard | `text` |  | Recorded Area (text) |
+| `recrdareano` | standard | `double precision` |  | Recorded Area (number) |
+| `gisacre` | standard | `double precision` |  | County-Provided Acres |
+| `sqft` | standard | `double precision` |  | County-Provided Parcel Square Feet |
+| `ll_gisacre` | standard | `double precision` |  | Loveland Calculated Parcel Acres |
+| `ll_gissqft` | standard | `bigint` |  | Loveland Calculated Parcel Square Feet |
+| `ll_bldg_footprint_sqft` | premium | `integer` |  | Loveland Calculated Building Footprint Square Feet |
+| `ll_bldg_count` | premium | `integer` |  | Loveland Calculated Building Count |
+| `reviseddate` | basic | `date` |  | Date of Last Revision |
+| `path` | basic | `text` |  | Parcel Path |
+| `ll_stable_id` | basic | `text` | preserved (if unchanged) | Stable ID |
+| `ll_uuid` | basic | `UUID` |  | Version 4 UUID |
+| `ll_updated_at` | basic | `timestamp with time zone` |  | Updated At |
+| `dpv_status` | premium | `text` |  | USPS Delivery Point Validation |
+| `dpv_codes` | premium | `text` |  | Delivery Point Validation Codes |
+| `dpv_notes` | premium | `text` |  | Delivery Point Validation Notes |
+| `dpv_type` | premium | `text` |  | Delivery Point Match Type |
+| `cass_errorno` | premium | `text` |  | CASS Certification Error Codes |
+| `rdi` | premium | `text` |  | Residential Delivery Indicator |
+| `usps_vacancy` | premium | `text` |  | USPS Vacancy Indicator |
+| `usps_vacancy_date` | premium | `date` |  | USPS Vacancy Indicator Date |
+| `lbcs_activity` | standard | `numeric` |  | LBCS Activity Code |
+| `lbcs_activity_desc` | standard | `text` |  | LBCS Activity Code text description |
+| `lbcs_function` | standard | `numeric` |  | LBCS Function Code |
+| `lbcs_function_desc` | standard | `text` |  | LBCS Function Code text description |
+| `lbcs_structure` | standard | `numeric` |  | LBCS Structure Code |
+| `lbcs_structure_desc` | standard | `text` |  | LBCS Structure Code text description |
+| `lbcs_site` | standard | `numeric` |  | LBCS Site Code |
+| `lbcs_site_desc` | standard | `text` |  | LBCS Site Code text description |
+| `lbcs_ownership` | standard | `numeric` |  | LBCS Ownership Code |
+| `lbcs_ownership_desc` | standard | `text` |  | LBCS Ownership Code text description |
 
 ## To update
 

--- a/schema.yml
+++ b/schema.yml
@@ -157,40 +157,40 @@ owntype:
 owner:
   type: text
   human: Owner Name
-  tier: standard
+  tier: basic
   categories: 
     - assessor_data
     - owner_address
 ownfrst:
   type: text
   human: Owner First Name
-  tier: standard
+  tier: basic
   categories: 
     - assessor_data
     - owner_address
 ownlast:
   type: text
   human: Owner Last Name
-  tier: standard
+  tier: basic
   categories: 
     - assessor_data
     - owner_address
 owner2:
   type: text
   human: Second Owner Name
-  tier: standard
+  tier: basic
   categories: 
     - assessor_data
 owner3:
   type: text
   human: Third Owner Name
-  tier: standard
+  tier: basic
   categories: 
     - assessor_data
 owner4:
   type: text
   human: Fourth Owner Name
-  tier: standard
+  tier: basic
   categories: 
     - assessor_data
 subsurfown:
@@ -470,19 +470,19 @@ census_blockgroup:
 sourceref:
   type: text
   human: Source Document Reference
-  tier: standard
+  tier: basic
   categories: 
     - core
 sourcedate:
   type: date
   human: Source Document Date
-  tier: standard
+  tier: basic
   categories: 
     - core
 sourceurl:
   type: text
   human: Source URL
-  tier: standard
+  tier: basic
   categories: 
     - core
 recrdareatx:
@@ -542,7 +542,7 @@ ll_bldg_count:
 reviseddate:
   type: date
   human: Date of Last Revision
-  tier: standard
+  tier: basic
   categories: 
     - core
 path:

--- a/schema.yml
+++ b/schema.yml
@@ -1,16 +1,19 @@
 ogc_fid:
   type: serial primary key
   human: object ID
+  tier: basic
   categories: 
     - core
 geoid:
   type: text
   human: FIPS code
+  tier: basic
   categories: 
     - core
 sourceagent:
   type: text
   human: Source Agent
+  tier: basic
   categories: 
     - core
 parcelnumb:
@@ -19,62 +22,74 @@ parcelnumb:
   examples:
     - "02004940"
     - "001-020-4624-001"
+  tier: basic
   categories: 
     - assessor_data
     - core
 usecode:
   type: text
   human: Parcel Use Code
+  tier: standard
   categories: 
     - assessor_data
 usedesc:
   type: text
   human: Parcel Use Description
+  tier: standard
   categories: 
     - assessor_data
 zoning:
   type: text
   human: Zoning Code
+  tier: standard
   categories: 
     - assessor_data
 zoning_description:
   type: text
   human: Zoning Description
+  tier: standard
   categories: 
     - assessor_data
 struct:
   type: boolean
   human: Structure On Parcel
+  tier: standard
   categories: 
     - assessor_data
 multistruct:
   type: boolean
   human: Multiple Structures on Parcel
+  tier: standard
   categories: 
     - assessor_data
 structno:
   type: integer
   human: Number of Structures on Parcel
+  tier: standard
   categories: 
     - assessor_data
 yearbuilt:
   type: integer
   human: Structure Year Built
+  tier: standard
   categories: 
     - assessor_data
 numstories:
   type: double precision
   human: Number of Stories
+  tier: standard
   categories: 
     - assessor_data
 numunits:
   type: integer
   human: Number of Units
+  tier: standard
   categories: 
     - assessor_data
 structstyle:
   type: text
   human: Structure Style
+  tier: standard
   categories: 
     - assessor_data
 parvaltype:
@@ -88,360 +103,430 @@ parvaltype:
     - 'Taxable'
     - 'Market'
     - 'Market Value'
+  tier: standard
   categories: 
     - assessor_data
 improvval:
   type: double precision
   human: Improvement Value
+  tier: standard
   categories: 
     - assessor_data
 landval:
   type: double precision
   human: Land Value
+  tier: standard
   categories: 
     - assessor_data
 parval:
   type: double precision
   human: Total Parcel Value
+  tier: standard
   categories: 
     - assessor_data
 agval:
   type: double precision
   human: Agricultural Value
+  tier: standard
   categories: 
     - assessor_data
 saleprice:
   type: double precision
   human: Last Sale Price
+  tier: standard
   categories: 
     - assessor_data
 saledate:
   type: date
   human: Last Sale Date
+  tier: standard
   categories: 
     - assessor_data
 taxamt:
   type: double precision
   human: Annual Tax Bill
+  tier: standard
   categories: 
     - assessor_data
 owntype:
   type: text
   human: Owner Type
+  tier: standard
   categories: 
     - assessor_data
 owner:
   type: text
   human: Owner Name
+  tier: standard
   categories: 
     - assessor_data
     - owner_address
 ownfrst:
   type: text
   human: Owner First Name
+  tier: standard
   categories: 
     - assessor_data
     - owner_address
 ownlast:
   type: text
   human: Owner Last Name
+  tier: standard
   categories: 
     - assessor_data
     - owner_address
 owner2:
   type: text
   human: Second Owner Name
+  tier: standard
   categories: 
     - assessor_data
 owner3:
   type: text
   human: Third Owner Name
+  tier: standard
   categories: 
     - assessor_data
 owner4:
   type: text
   human: Fourth Owner Name
+  tier: standard
   categories: 
     - assessor_data
 subsurfown:
   type: text
   human: Subsurface Owner
+  tier: standard
   categories: 
     - assessor_data
 subowntype:
   type: text
   human: Subsurface Owner Type
+  tier: standard
   categories: 
     - assessor_data
 mailadd:
   type: text
   human: Owner Mailing Address
+  tier: standard
   categories: 
     - owner_address
 mail_address2:
   type: text
   human: Owner Mailing Address Second Line
+  tier: standard
   categories: 
     - owner_address
 careof:
   type: text
   human: Owner Mailing Address Care Of
+  tier: standard
   categories: 
     - owner_address
 mail_addno:
   type: text
   human: Owner Mailing Address Street Number
+  tier: standard
   categories: 
     - owner_address
 mail_addpref:
   type: text
   human: Owner Mailing Address Street Prefix
+  tier: standard
   categories: 
     - owner_address
 mail_addstr:
   type: text
   human: Owner Mailing Address Street Name
+  tier: standard
   categories: 
     - owner_address
 mail_addsttyp:
   type: text
   human: Owner Mailing Address Street Type
+  tier: standard
   categories: 
     - owner_address
 mail_addstsuf:
   type: text
   human: Owner Mailing Address Street Suffix
+  tier: standard
   categories: 
     - owner_address
 mail_unit:
   type: text
   human: Owner Mailing Address Unit Number
+  tier: standard
   categories: 
     - owner_address
 mail_city:
   type: text
   human: Owner Mailing Address City
+  tier: standard
   categories: 
     - owner_address
 mail_state2:
   type: text
   human: Owner Mailing Address State
+  tier: standard
   categories: 
     - owner_address
 mail_zip:
   type: text
   human: Owner Mailing Address ZIP Code
+  tier: standard
   categories: 
     - owner_address
 mail_urbanization:
   type: text
   human: Mailing Address Urbanizacion (Puerto Rico)
+  tier: standard
   categories: 
     - owner_address
 address:
   type: text
   human: Site Address
+  tier: basic
   categories: 
     - situs_address
 address2:
   type: text
   human: Site Address Second Line
+  tier: basic
   categories: 
     - situs_address
 saddno:
   type: text
   human: Site Address Number
+  tier: basic
   categories: 
     - situs_address
 saddpref:
   type: text
   human: Site Address Prefix
+  tier: basic
   categories: 
     - situs_address
 saddstr:
   type: text
   human: Site Address Street Name
+  tier: basic
   categories: 
     - situs_address
 saddsttyp:
   type: text
   human: Site Address Street Type
+  tier: basic
   categories: 
     - situs_address
 saddstsuf:
   type: text
   human: Site Address Street Suffix
+  tier: basic
   categories: 
     - situs_address
 sunit:
   type: text
   human: Site Address Unit
+  tier: basic
   categories: 
     - situs_address
 scity:
   type: text
   human: Site Address City
+  tier: basic
   categories: 
     - situs_address
 original_address:
   type: text
   human: Original Address
   description: Address fields as originally provided by the county, separated by a semicolon and a space
+  tier: basic
   categories: 
     - situs_address
 city:
   type: text
   human: Census City
+  tier: basic
   categories: 
     - core
 county:
   type: text
   human: Site Address County
+  tier: basic
   categories: 
     - situs_address
 state2:
   type: text
   human: Site Address State
+  tier: basic
   categories: 
     - situs_address
 szip:
   type: text
   human: Site Address Zip Code
+  tier: basic
   categories: 
     - situs_address
 urbanization:
   type: text
   human: Site Urbanizacion
   description: A postal address field commonly used in Puerto Rico
+  tier: basic
   categories: 
     - situs_address
 location_name:
   type: text
   human: Location Name
   description: A name commonly associated with this parcel
+  tier: basic
   categories: 
     - situs_address
 address_source:
   type: text
   human: Primary Address Source
   default: "'county'"
+  tier: basic
   categories: 
     - situs_address
 legaldesc:
   type: text
   human: Legal Description
+  tier: standard
   categories: 
     - assessor_data
 plat:
   type: text
   human: Plat
+  tier: standard
   categories: 
     - assessor_data
 book:
   type: text
   human: Book
+  tier: standard
   categories: 
     - assessor_data
 page:
   type: text
   human: Page
+  tier: standard
   categories: 
     - assessor_data
 block:
   type: text
   human: Block
+  tier: standard
   categories: 
     - assessor_data
 lot:
   type: text
   human: Lot
+  tier: standard
   categories: 
     - assessor_data
 neighborhood:
   type: text
   human: Neighborhood
+  tier: standard
   categories: 
     - assessor_data
 subdivision:
   type: text
   human: Subdivision
+  tier: standard
   categories: 
     - assessor_data
 qoz:
   type: text
   human: Federal Qualified Opportunity Zone
+  tier: standard
   categories: 
     - assessor_data
 qoz_tract:
   type: text
   human: Qualified Opportunity Zone 2018 Census Tract Number
+  tier: standard
   categories: 
     - assessor_data
 census_tract:
   type: text
   human: Census 2010 Tract
+  tier: standard
   categories: 
     - census
 census_block:
   type: text
   human: Census 2010 Block
+  tier: standard
   categories: 
     - census
 census_blockgroup:
   type: text
   human: Census 2010 Blockgroup
+  tier: standard
   categories: 
     - census
 sourceref:
   type: text
   human: Source Document Reference
+  tier: standard
   categories: 
     - core
 sourcedate:
   type: date
   human: Source Document Date
+  tier: standard
   categories: 
     - core
 sourceurl:
   type: text
   human: Source URL
+  tier: standard
   categories: 
     - core
 recrdareatx:
   type: text
   human: Recorded Area (text)
+  tier: standard
   categories: 
     - assessor_data
 recrdareano:
   type: double precision
   human: Recorded Area (number)
+  tier: standard
   categories: 
     - assessor_data
 gisacre:
   type: double precision
   human: County-Provided Acres
+  tier: standard
   categories: 
     - assessor_data
 sqft:
   type: double precision
   human: County-Provided Parcel Square Feet
+  tier: standard
   categories: 
     - assessor_data
 ll_gisacre:
   type: double precision
   human: Loveland Calculated Parcel Acres
+  tier: standard
   categories: 
     - assessor_data
     - calculated
 ll_gissqft:
   type: bigint
   human: Loveland Calculated Parcel Square Feet
+  tier: standard
   categories: 
     - assessor_data
     - calculated
 ll_bldg_footprint_sqft:
   type: integer
   human: Loveland Calculated Building Footprint Square Feet
+  tier: premium
   categories: 
     - calculated
     - bldg
@@ -449,6 +534,7 @@ ll_bldg_footprint_sqft:
 ll_bldg_count:
   type: integer
   human: Loveland Calculated Building Count
+  tier: premium
   categories: 
     - calculated
     - bldg
@@ -456,18 +542,21 @@ ll_bldg_count:
 reviseddate:
   type: date
   human: Date of Last Revision
+  tier: standard
   categories: 
     - core
 path:
   type: text
   human: Parcel Path
   description: A human-readable identifier for this parcel. Set automatically by Loveland.
+  tier: basic
   categories: 
     - core
 ll_stable_id:
   type: text
   human: Stable ID
   description: Does this parcel have a stable ogc_fid from the last update?
+  tier: basic
   categories: 
     - core
   examples:
@@ -477,6 +566,7 @@ ll_uuid:
   default: uuid_generate_v4()
   human: Version 4 UUID
   description: Uniquely identifies a single parcel
+  tier: basic
   categories: 
     - core
 ll_updated_at:
@@ -484,54 +574,63 @@ ll_updated_at:
   default: now()
   human: Updated At
   description: Timestamp of last update of any kind to this row
+  tier: basic
   categories: 
     - core
 dpv_status:
   type: text
   human: USPS Delivery Point Validation
   description: USPS delivery point validation status code
+  tier: premium
   categories: 
     - usps
     - premium
 dpv_codes:
   type: text
   human: Delivery Point Validation Codes
+  tier: premium
   categories: 
     - usps
     - premium
 dpv_notes:
   type: text
   human: Delivery Point Validation Notes
+  tier: premium
   categories: 
     - usps
     - premium
 dpv_type:
   type: text
   human: Delivery Point Match Type
+  tier: premium
   categories: 
     - usps
     - premium
 cass_errorno:
   type: text
   human: CASS Certification Error Codes
+  tier: premium
   categories: 
     - usps
     - premium
 rdi:
   type: text
   human: Residential Delivery Indicator
+  tier: premium
   categories: 
     - usps
     - premium
 usps_vacancy:
   type: text
   human: USPS Vacancy Indicator
+  tier: premium
   categories: 
     - usps
     - premium
 usps_vacancy_date:
   type: date
   human: USPS Vacancy Indicator Date
+  tier: premium
   categories: 
     - usps
     - premium
@@ -539,59 +638,69 @@ lbcs_activity:
   type: numeric
   human: LBCS Activity Code
   description: Actual activity on land, eg farming, shopping, manufacturing. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_activity_desc:
   type: text
   human: LBCS Activity Code text description
   description: Actual activity on land, eg farming, shopping, manufacturing. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_function:
   type: numeric
   human: LBCS Function Code
   description: Economic function or type of establishment, eg agricultural, commercial, industrial. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_function_desc:
   type: text
   human: LBCS Function Code text description
   description: Economic function or type of establishment, eg agricultural, commercial, industrial. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_structure:
   type: numeric
   human: LBCS Structure Code
   description: Type of structure or building, eg single-family house, office building, warehouse. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_structure_desc:
   type: text
   human: LBCS Structure Code text description
   description: Type of structure or building, eg single-family house, office building, warehouse. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_site:
   type: numeric
   human: LBCS Site Code
   description: What is on the land. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_site_desc:
   type: text
   human: LBCS Site Code text description
   description: What is on the land. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_ownership:
   type: numeric
   human: LBCS Ownership Code
   description: Ownership structure, eg public, private. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs
 lbcs_ownership_desc:
   type: text
   human: LBCS Ownership Code text description
   description: Ownership structure, eg public, private. See https://www.planning.org/lbcs/standards/
+  tier: standard
   categories: 
     - lbcs

--- a/update.rb
+++ b/update.rb
@@ -11,14 +11,14 @@ File.open('schema.sql', 'w') { |file| file.puts sql }
 
 # Update the readme
 docs = []
-docs << '| Field | Type | Examples | Description |'
-docs << '| ----- | ---- | -------- | ----------- |'
+docs << '| Field | Tier | Type | Examples | Description |'
+docs << '| ----- | ---- | ---- | -------- | ----------- |'
 
 schema.map do |s, v|
   puts s
   puts v
   examples = v['examples'].join(', ') if v['examples']
-  docs << "| `#{s}` | `#{v['type']}` | #{examples} | #{v['human']} |"
+  docs << "| `#{s}` | #{v['tier']} | `#{v['type']}` | #{examples} | #{v['human']} |"
 end
 new_readme = "## Schema\n\n"
 new_readme += docs.join("\n")


### PR DESCRIPTION
Blake, for your eyes and discussion -- I think we need to list the tier of each field in the schema doc to make it clear what's available at each level. Here's a pass over that; I'm sure it will need adjustment 

You can view the "rich diff" or just the file of readme.md for a skimmable table. 

This ignores the thought that LBCS might become premium in the near future. 

The one I'm curious about is putting the source doc info in basic -- but if they are delivered that way right now no reason to change. 
```
| `sourceref` | basic | `text` |  | Source Document Reference |
| `sourcedate` | basic | `date` |  | Source Document Date |
| `sourceurl` | basic | `text` |  | Source URL |
```
