### PR TITLE
Add descriptions to schema

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -6,8 +6,8 @@ ogc_fid:
     - core
 geoid:
   type: text
-  human: FIPS code
-  description: State + county FIPS codes
+  human: FIPS Code
+  description: FIPS code (state + county FIPS codes)
   tier: basic
   categories: 
     - core
@@ -65,7 +65,7 @@ zoning_description:
     - assessor_data
 struct:
   type: boolean
-  human: Structure On Parcel
+  human: Structure on Parcel
   tier: standard
   categories: 
     - assessor_data
@@ -123,7 +123,7 @@ improvval:
   type: double precision
   human: Improvement Value
   tier: standard
-  categories: 
+  categories:
     - assessor_data
 landval:
   type: double precision
@@ -255,7 +255,7 @@ mail_addpref:
     - owner_address
 mail_addstr:
   type: text
-  human: Owner Mailing Address Street Name
+  human: Mailing Address Street Name
   examples:
     - FOURTH
   tier: standard
@@ -263,7 +263,7 @@ mail_addstr:
     - owner_address
 mail_addsttyp:
   type: text
-  human: Owner Mailing Address Street Type
+  human: Mailing Address Street Type
   examples:
     - AVE
   tier: standard
@@ -271,7 +271,7 @@ mail_addsttyp:
     - owner_address
 mail_addstsuf:
   type: text
-  human: Owner Mailing Address Street Suffix
+  human: Mailing Address Street Suffix
   examples:
     - NW
   tier: standard
@@ -279,7 +279,7 @@ mail_addstsuf:
     - owner_address
 mail_unit:
   type: text
-  human: Owner Mailing Address Unit Number
+  human: Mailing Address Unit Number
   examples: 
     - "APT # 2"
   tier: standard
@@ -287,7 +287,7 @@ mail_unit:
     - owner_address
 mail_city:
   type: text
-  human: Owner Mailing Address City
+  human: Mailing Address City
   examples:
     - Ann Arbor
   tier: standard
@@ -295,7 +295,7 @@ mail_city:
     - owner_address
 mail_state2:
   type: text
-  human: Owner Mailing Address State
+  human: Mailing Address State
   examples:
     - MI
   tier: standard
@@ -303,7 +303,7 @@ mail_state2:
     - owner_address
 mail_zip:
   type: text
-  human: Owner Mailing Address ZIP Code
+  human: Mailing Address ZIP Code
   tier: standard
   categories: 
     - owner_address
@@ -315,8 +315,8 @@ mail_urbanization:
     - owner_address
 address:
   type: text
-  human: Site Address
-  description: This is the address of the parcel itself. Not every parcel has a street address, especially in agricultural areas and other large parcels. Also called the "situs address" or "site address".
+  human: Parcel Address
+  description: This is the address of the parcel itself. Also called the "situs address" or "site address". Not every parcel has a street address, especially in agricultural areas and other large parcels.
   examples:
     - 12109 KATZ RD
   tier: basic
@@ -324,7 +324,7 @@ address:
     - situs_address
 address2:
   type: text
-  human: Site Address Second Line
+  human: Parcel Address Second Line
   examples: 
     - Apt 2
     - Unit B
@@ -334,7 +334,7 @@ address2:
     - situs_address
 saddno:
   type: text
-  human: Site Address Number
+  human: Parcel Address Number
   examples:
     - "12109"
   tier: basic
@@ -342,7 +342,7 @@ saddno:
     - situs_address
 saddpref:
   type: text
-  human: Site Address Prefix
+  human: Parcel Address Prefix
   examples:
     - N
   tier: basic
@@ -350,7 +350,7 @@ saddpref:
     - situs_address
 saddstr:
   type: text
-  human: Site Address Street Name
+  human: Parcel Address Street Name
   examples:
     - GLENN
   tier: basic
@@ -358,7 +358,7 @@ saddstr:
     - situs_address
 saddsttyp:
   type: text
-  human: Site Address Street Type
+  human: Parcel Address Street Type
   examples:
     - RD
   tier: basic
@@ -366,7 +366,7 @@ saddsttyp:
     - situs_address
 saddstsuf:
   type: text
-  human: Site Address Street Suffix
+  human: Parcel Address Street Suffix
   examples:
     - NW
   tier: basic
@@ -374,13 +374,13 @@ saddstsuf:
     - situs_address
 sunit:
   type: text
-  human: Site Address Unit
+  human: Parcel Address Unit
   tier: basic
   categories: 
     - situs_address
 scity:
   type: text
-  human: Site Address City
+  human: Parcel Address City
   examples:
     - GRASS LAKE
   tier: basic
@@ -388,7 +388,7 @@ scity:
     - situs_address
 original_address:
   type: text
-  human: Original Address
+  human: Original Parcel Address
   description: Address fields as originally provided by the county, separated by a semicolon and a space
   examples: 
     - 12109 Katz Rd; NW; Ann Arbor; MI; 48105
@@ -397,19 +397,21 @@ original_address:
     - situs_address
 city:
   type: text
-  human: Census City
+  human: US Census County Subdivision
+  description: Used for organizational purposes. Refer to scity for the city associated with the site address.
   tier: basic
+  link: https://www2.census.gov/geo/pdfs/reference/GARM/Ch8GARM.pdf
   categories: 
     - core
 county:
   type: text
-  human: Site Address County
+  human: Parcel Address County
   tier: basic
   categories: 
     - situs_address
 state2:
   type: text
-  human: Site Address State
+  human: Parcel Address State
   examples:
     - MI
   tier: basic
@@ -417,7 +419,7 @@ state2:
     - situs_address
 szip:
   type: text
-  human: Site Address Zip Code
+  human: Parcel Address Zip Code
   examples: 
     - "48103"
     - 48104-3423
@@ -426,7 +428,7 @@ szip:
     - situs_address
 urbanization:
   type: text
-  human: Site Urbanizacion
+  human: Parcel Urbanizacion
   description: A postal address field commonly used in Puerto Rico
   example: Caguas
   tier: basic
@@ -442,8 +444,13 @@ location_name:
 address_source:
   type: text
   human: Primary Address Source
+  description: Default source if none is listed is the county.
   default: "'county'"
   tier: basic
+  examples: 
+    -openaddresses
+    -accuzip
+    -county
   categories: 
     - situs_address
 legaldesc:
@@ -592,7 +599,7 @@ sqft:
 ll_gisacre:
   type: double precision
   human: Loveland Calculated Parcel Acres
-  description: Parcel acres as calculated by Loveland from county parcel geometry
+  description: Parcel acres as calculated by Loveland from the parcel geometry
   tier: standard
   categories: 
     - assessor_data
@@ -600,7 +607,7 @@ ll_gisacre:
 ll_gissqft:
   type: bigint
   human: Loveland Calculated Parcel Square Feet
-  description: Parcel square feet as calculated by Loveland from county parcel geometry
+  description: Parcel square feet as calculated by Loveland from the parcel geometry
   tier: standard
   categories: 
     - assessor_data
@@ -633,7 +640,7 @@ reviseddate:
 path:
   type: text
   human: Parcel Path
-  description: A human-readable identifier for this parcel. Set automatically by Loveland.
+  description: Loveland's human-readable identifier for this parcel. Not guaranteed to be stable between updates.
   examples:
     - /us/mi/wayne/detroit/123
     - /us/ny/new-york/manhattan/375553
@@ -656,7 +663,7 @@ ll_uuid:
   type: uuid
   default: uuid_generate_v4()
   human: UUID
-  description: Uniquely identifies a single parcel with a v4 uuid. A stable parcel id across county data refreshes. It is the value that should be used for tracking indiviual parcels.
+  description: Uniquely identifies a single parcel with a v4 uuid. A stable parcel id across county data refreshes. This field should be used for tracking indiviual parcels.
   examples:
     - 4cc9eda6-883c-4f38-9a07-b44900a64b16
   tier: basic
@@ -750,7 +757,7 @@ lbcs_activity:
     - lbcs
 lbcs_activity_desc:
   type: text
-  human: LBCS Activity Code text description
+  human: LBCS Activity Code Description
   description: Description of the LBCS numeric code 
   link: https://www.planning.org/lbcs/standards/activity
   tier: standard
@@ -766,7 +773,7 @@ lbcs_function:
     - lbcs
 lbcs_function_desc:
   type: text
-  human: LBCS Function Code text description
+  human: LBCS Function Code Description
   description: Economic function or type of establishment, eg agricultural, commercial, industrial
   link: https://www.planning.org/lbcs/standards/function
   tier: standard
@@ -782,7 +789,7 @@ lbcs_structure:
     - lbcs
 lbcs_structure_desc:
   type: text
-  human: LBCS Structure Code text description
+  human: LBCS Structure Code Description
   description: Type of structure or building, eg single-family house, office building, warehouse
   link: https://www.planning.org/lbcs/standards/structure
   tier: standard
@@ -798,7 +805,7 @@ lbcs_site:
     - lbcs
 lbcs_site_desc:
   type: text
-  human: LBCS Site Code text description
+  human: LBCS Site Code Description
   description: What is on the land
   link: https://www.planning.org/lbcs/standards/site
   tier: standard
@@ -814,7 +821,7 @@ lbcs_ownership:
     - lbcs
 lbcs_ownership_desc:
   type: text
-  human: LBCS Ownership Code text description
+  human: LBCS Ownership Code Description
   description: Ownership structure, eg public, private
   link: https://www.planning.org/lbcs/standards/ownership
   tier: standard

--- a/schema.yml
+++ b/schema.yml
@@ -1,12 +1,13 @@
 ogc_fid:
   type: serial primary key
-  human: object ID
+  human: Object ID
   tier: basic
   categories: 
     - core
 geoid:
   type: text
   human: FIPS code
+  description: State + county FIPS codes
   tier: basic
   categories: 
     - core
@@ -29,24 +30,36 @@ parcelnumb:
 usecode:
   type: text
   human: Parcel Use Code
+  description: Varies by governing municipality
+  examples: 
+    - 104
   tier: standard
   categories: 
     - assessor_data
 usedesc:
   type: text
   human: Parcel Use Description
+  description: Varies by governing municipality
+  examples: 
+    - Residential
   tier: standard
   categories: 
     - assessor_data
 zoning:
   type: text
   human: Zoning Code
+  description: Varies by governing municipality
+  examples: 
+    - R-1
   tier: standard
   categories: 
     - assessor_data
 zoning_description:
   type: text
   human: Zoning Description
+  description: Varies by governing municipality
+  examples: 
+    - Residential
   tier: standard
   categories: 
     - assessor_data
@@ -207,67 +220,84 @@ subowntype:
     - assessor_data
 mailadd:
   type: text
-  human: Owner Mailing Address
+  human: Mailing Address
+  description: This is the address where the tax and other assessor's communications are sent. It is often thought of as the owner's mailing address. It is often the same address as the parcel phyiscal street address, but very commonly it is a different address than the parcel address itself. 
   tier: standard
   categories: 
     - owner_address
 mail_address2:
   type: text
-  human: Owner Mailing Address Second Line
+  human: Mailing Address Second Line
   tier: standard
   categories: 
     - owner_address
 careof:
   type: text
-  human: Owner Mailing Address Care Of
+  human: Mailing Address Care Of
   tier: standard
   categories: 
     - owner_address
 mail_addno:
   type: text
-  human: Owner Mailing Address Street Number
+  human: Mailing Address Street Number
+  examples:
+    - "402"
   tier: standard
   categories: 
     - owner_address
 mail_addpref:
   type: text
-  human: Owner Mailing Address Street Prefix
+  human: Mailing Address Street Prefix
   tier: standard
+  examples:
+    - S
   categories: 
     - owner_address
 mail_addstr:
   type: text
   human: Owner Mailing Address Street Name
+  examples:
+    - FOURTH
   tier: standard
   categories: 
     - owner_address
 mail_addsttyp:
   type: text
   human: Owner Mailing Address Street Type
+  examples:
+    - AVE
   tier: standard
   categories: 
     - owner_address
 mail_addstsuf:
   type: text
   human: Owner Mailing Address Street Suffix
+  examples:
+    - NW
   tier: standard
   categories: 
     - owner_address
 mail_unit:
   type: text
   human: Owner Mailing Address Unit Number
+  examples: 
+    - "APT # 2"
   tier: standard
   categories: 
     - owner_address
 mail_city:
   type: text
   human: Owner Mailing Address City
+  examples:
+    - Ann Arbor
   tier: standard
   categories: 
     - owner_address
 mail_state2:
   type: text
   human: Owner Mailing Address State
+  examples:
+    - MI
   tier: standard
   categories: 
     - owner_address
@@ -286,42 +316,59 @@ mail_urbanization:
 address:
   type: text
   human: Site Address
+  description: This is the address of the parcel itself. Not every parcel has a street address, especially in agricultural areas and other large parcels. Also called the "situs address" or "site address".
+  examples:
+    - 12109 KATZ RD
   tier: basic
   categories: 
     - situs_address
 address2:
   type: text
   human: Site Address Second Line
+  examples: 
+    - Apt 2
+    - Unit B
+    - 6th floor
   tier: basic
   categories: 
     - situs_address
 saddno:
   type: text
   human: Site Address Number
+  examples:
+    - "12109"
   tier: basic
   categories: 
     - situs_address
 saddpref:
   type: text
   human: Site Address Prefix
+  examples:
+    - N
   tier: basic
   categories: 
     - situs_address
 saddstr:
   type: text
   human: Site Address Street Name
+  examples:
+    - GLENN
   tier: basic
   categories: 
     - situs_address
 saddsttyp:
   type: text
   human: Site Address Street Type
+  examples:
+    - RD
   tier: basic
   categories: 
     - situs_address
 saddstsuf:
   type: text
   human: Site Address Street Suffix
+  examples:
+    - NW
   tier: basic
   categories: 
     - situs_address
@@ -334,6 +381,8 @@ sunit:
 scity:
   type: text
   human: Site Address City
+  examples:
+    - GRASS LAKE
   tier: basic
   categories: 
     - situs_address
@@ -341,6 +390,8 @@ original_address:
   type: text
   human: Original Address
   description: Address fields as originally provided by the county, separated by a semicolon and a space
+  examples: 
+    - 12109 Katz Rd; NW; Ann Arbor; MI; 48105
   tier: basic
   categories: 
     - situs_address
@@ -359,12 +410,17 @@ county:
 state2:
   type: text
   human: Site Address State
+  examples:
+    - MI
   tier: basic
   categories: 
     - situs_address
 szip:
   type: text
   human: Site Address Zip Code
+  examples: 
+    - "48103"
+    - 48104-3423
   tier: basic
   categories: 
     - situs_address
@@ -372,6 +428,7 @@ urbanization:
   type: text
   human: Site Urbanizacion
   description: A postal address field commonly used in Puerto Rico
+  example: Caguas
   tier: basic
   categories: 
     - situs_address
@@ -398,18 +455,27 @@ legaldesc:
 plat:
   type: text
   human: Plat
+  description: Plat number the parcel is recorded on
+  examples:
+    - A
   tier: standard
   categories: 
     - assessor_data
 book:
   type: text
   human: Book
+  description: Book/Liber the parcel is recorded in
+  examples:
+    - 231
   tier: standard
   categories: 
     - assessor_data
 page:
   type: text
   human: Page
+  description: Page/Folio the parcel is recorded on
+  examples: 
+    - 2
   tier: standard
   categories: 
     - assessor_data
@@ -440,12 +506,21 @@ subdivision:
 qoz:
   type: text
   human: Federal Qualified Opportunity Zone
+  description: Is this parcel in a US Federal Qualified Opportunity Zone
+  examples:
+    - "Yes"
+    - "No"
   tier: standard
   categories: 
     - assessor_data
 qoz_tract:
   type: text
   human: Qualified Opportunity Zone 2018 Census Tract Number
+  description: "Census tract number as it was defined in Dec 2018 when QOZs were designated."
+  link: https://www.irs.gov/newsroom/opportunity-zones-frequently-asked-questions
+  examples:
+    - 30059000100
+    - 30107000100
   tier: standard
   categories: 
     - assessor_data
@@ -470,30 +545,35 @@ census_blockgroup:
 sourceref:
   type: text
   human: Source Document Reference
+  description: A county provided reference for the parcel record
   tier: basic
   categories: 
     - core
 sourcedate:
   type: date
   human: Source Document Date
+  description: A county provided date for the parcel record
   tier: basic
   categories: 
     - core
 sourceurl:
   type: text
   human: Source URL
+  description: A county provided url to the county parcel record online
   tier: basic
   categories: 
     - core
 recrdareatx:
   type: text
   human: Recorded Area (text)
+  deprecated: true
   tier: standard
   categories: 
     - assessor_data
 recrdareano:
   type: double precision
   human: Recorded Area (number)
+  deprecated: true
   tier: standard
   categories: 
     - assessor_data
@@ -512,6 +592,7 @@ sqft:
 ll_gisacre:
   type: double precision
   human: Loveland Calculated Parcel Acres
+  description: Parcel acres as calculated by Loveland from county parcel geometry
   tier: standard
   categories: 
     - assessor_data
@@ -519,6 +600,7 @@ ll_gisacre:
 ll_gissqft:
   type: bigint
   human: Loveland Calculated Parcel Square Feet
+  description: Parcel square feet as calculated by Loveland from county parcel geometry
   tier: standard
   categories: 
     - assessor_data
@@ -526,6 +608,7 @@ ll_gissqft:
 ll_bldg_footprint_sqft:
   type: integer
   human: Loveland Calculated Building Footprint Square Feet
+  description: Total building footprint in square feet as calculated by Loveland
   tier: premium
   categories: 
     - calculated
@@ -534,6 +617,7 @@ ll_bldg_footprint_sqft:
 ll_bldg_count:
   type: integer
   human: Loveland Calculated Building Count
+  description: Total number of buildings on the parcel as calculated by Loveland
   tier: premium
   categories: 
     - calculated
@@ -542,6 +626,7 @@ ll_bldg_count:
 reviseddate:
   type: date
   human: Date of Last Revision
+  description: The last date of last revision as provided by the county assessor's office if available. 
   tier: basic
   categories: 
     - core
@@ -549,23 +634,31 @@ path:
   type: text
   human: Parcel Path
   description: A human-readable identifier for this parcel. Set automatically by Loveland.
+  examples:
+    - /us/mi/wayne/detroit/123
+    - /us/ny/new-york/manhattan/375553
   tier: basic
   categories: 
     - core
 ll_stable_id:
   type: text
   human: Stable ID
-  description: Does this parcel have a stable ogc_fid from the last update?
+  description: Indicates if the path and ll_uuid values have changed during the last refresh from the county. A value of 'preserved' means the 'll_uuid' was matched during county refresh to the previous data. A 'null' indicates a new ll_uuid was generated because the new data was not matched to the existing data during the county data refresh process.
+  examples:
+    - preserved
+    - null
   tier: basic
   categories: 
     - core
   examples:
     - preserved (if unchanged)
 ll_uuid:
-  type: UUID
+  type: uuid
   default: uuid_generate_v4()
-  human: Version 4 UUID
-  description: Uniquely identifies a single parcel
+  human: UUID
+  description: Uniquely identifies a single parcel with a v4 uuid. A stable parcel id across county data refreshes. It is the value that should be used for tracking indiviual parcels.
+  examples:
+    - 4cc9eda6-883c-4f38-9a07-b44900a64b16
   tier: basic
   categories: 
     - core
@@ -573,14 +666,18 @@ ll_updated_at:
   type: timestamp with time zone
   default: now()
   human: Updated At
-  description: Timestamp of last update of any kind to this row
+  description: Timestamp of last update of any kind to this row, internal changes to row, and/or county updates.
+  examples: 
+    - "2019-06-06 12:45:21.285102-04"
   tier: basic
   categories: 
     - core
 dpv_status:
   type: text
   human: USPS Delivery Point Validation
-  description: USPS delivery point validation status code
+  examples:
+    - V
+    - N
   tier: premium
   categories: 
     - usps
@@ -602,6 +699,9 @@ dpv_notes:
 dpv_type:
   type: text
   human: Delivery Point Match Type
+  examples:
+    - H (High Rise) 
+    - S (Street)
   tier: premium
   categories: 
     - usps
@@ -616,6 +716,9 @@ cass_errorno:
 rdi:
   type: text
   human: Residential Delivery Indicator
+  examples: 
+    - Y
+    - N
   tier: premium
   categories: 
     - usps
@@ -623,6 +726,8 @@ rdi:
 usps_vacancy:
   type: text
   human: USPS Vacancy Indicator
+  examples: 
+    - Y
   tier: premium
   categories: 
     - usps
@@ -630,6 +735,7 @@ usps_vacancy:
 usps_vacancy_date:
   type: date
   human: USPS Vacancy Indicator Date
+  description: Date the vacancy indicator was collected
   tier: premium
   categories: 
     - usps
@@ -637,70 +743,80 @@ usps_vacancy_date:
 lbcs_activity:
   type: numeric
   human: LBCS Activity Code
-  description: Actual activity on land, eg farming, shopping, manufacturing. See https://www.planning.org/lbcs/standards/
+  description: Actual activity on land, eg farming, shopping, manufacturing. 
+  link: https://www.planning.org/lbcs/standards/activity
   tier: standard
   categories: 
     - lbcs
 lbcs_activity_desc:
   type: text
   human: LBCS Activity Code text description
-  description: Actual activity on land, eg farming, shopping, manufacturing. See https://www.planning.org/lbcs/standards/
+  description: Description of the LBCS numeric code 
+  link: https://www.planning.org/lbcs/standards/activity
   tier: standard
   categories: 
     - lbcs
 lbcs_function:
   type: numeric
   human: LBCS Function Code
-  description: Economic function or type of establishment, eg agricultural, commercial, industrial. See https://www.planning.org/lbcs/standards/
+  description: Economic function or type of establishment, eg agricultural, commercial, industrial
+  link: https://www.planning.org/lbcs/standards/function
   tier: standard
   categories: 
     - lbcs
 lbcs_function_desc:
   type: text
   human: LBCS Function Code text description
-  description: Economic function or type of establishment, eg agricultural, commercial, industrial. See https://www.planning.org/lbcs/standards/
+  description: Economic function or type of establishment, eg agricultural, commercial, industrial
+  link: https://www.planning.org/lbcs/standards/function
   tier: standard
   categories: 
     - lbcs
 lbcs_structure:
   type: numeric
   human: LBCS Structure Code
-  description: Type of structure or building, eg single-family house, office building, warehouse. See https://www.planning.org/lbcs/standards/
+  description: Type of structure or building, eg single-family house, office building, warehouse
+  link: https://www.planning.org/lbcs/standards/structure
   tier: standard
   categories: 
     - lbcs
 lbcs_structure_desc:
   type: text
   human: LBCS Structure Code text description
-  description: Type of structure or building, eg single-family house, office building, warehouse. See https://www.planning.org/lbcs/standards/
+  description: Type of structure or building, eg single-family house, office building, warehouse
+  link: https://www.planning.org/lbcs/standards/structure
   tier: standard
   categories: 
     - lbcs
 lbcs_site:
   type: numeric
   human: LBCS Site Code
-  description: What is on the land. See https://www.planning.org/lbcs/standards/
+  description: What is on the land
+  link: https://www.planning.org/lbcs/standards/site
   tier: standard
   categories: 
     - lbcs
 lbcs_site_desc:
   type: text
   human: LBCS Site Code text description
-  description: What is on the land. See https://www.planning.org/lbcs/standards/
+  description: What is on the land
+  link: https://www.planning.org/lbcs/standards/site
   tier: standard
   categories: 
     - lbcs
 lbcs_ownership:
   type: numeric
   human: LBCS Ownership Code
-  description: Ownership structure, eg public, private. See https://www.planning.org/lbcs/standards/
+  description: Ownership structure, eg public, private
+  link: https://www.planning.org/lbcs/standards/ownership
   tier: standard
   categories: 
     - lbcs
 lbcs_ownership_desc:
   type: text
   human: LBCS Ownership Code text description
-  description: Ownership structure, eg public, private. See https://www.planning.org/lbcs/standards/
+  description: Ownership structure, eg public, private
+  link: https://www.planning.org/lbcs/standards/ownership
   tier: standard
   categories: 
     - lbcs


### PR DESCRIPTION
This is a work in progress!
Adding in the descriptions from https://docs.google.com/spreadsheets/d/14RcBKyiEGa7q-SR0rFnDHVcovb9uegPJ3sfb3WlNPc0/edit#gid=1495699317

Some notes:
- Doesn't yet note the proposed columns (I don't think we can list them here without them getting added to tables as we create them -- may need to list them by hand on the schema page
- The human-formatted column names have diverged a bit between the sheet and the yml (we use those for labeling in the web & mobile apps) 
- I noticed the value columns are labeled "in US Dollars". Could we switch to "in local currency" in anticipation of Canada?